### PR TITLE
Remove traces of Kite promotion from package settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,10 +165,6 @@
       "type": "boolean",
       "default": false,
       "description": "When enabled, text editor tokens are rendered as plain blocks, with no regards to the whitespaces they contains."
-    },
-    "disablePythonDocLinks": {
-      "type": "boolean",
-      "default": false
     }
   },
   "dependencies": {


### PR DESCRIPTION
Remove minor annoyance that brings sad memories from the Kite war. (Seriously, I'm just testing Atom's github integration),